### PR TITLE
PR時にデプロイが走らないように，GitHub actionsのmain.ymlを修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,9 @@
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Controls when the action will run.
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/api_server/views.py
+++ b/api_server/views.py
@@ -3,5 +3,5 @@ from django.http import JsonResponse
 
 def index(request):
     return JsonResponse(
-        data={'message': 'Hello, world from API server index, deployed with GitHub actions triggered by PullRequest'}
+        data={'message': 'Hello, world from API server index, deployed with GitHub actions triggered by PR merge'}
     )

--- a/api_server/views.py
+++ b/api_server/views.py
@@ -3,5 +3,5 @@ from django.http import JsonResponse
 
 def index(request):
     return JsonResponse(
-        data={'message': 'Hello, world from API server index, deployed with GitHub actions!'}
+        data={'message': 'Hello, world from API server index, deployed with GitHub actions triggered by PullRequest'}
     )


### PR DESCRIPTION
## 概要
* 現状，PRを出すとデプロイが走ってしまう．
* PRを出したタイミングでなく，マージしたタイミングでデプロイが走るよう，main.ymlを修正

## 技術的変更点
* `.github/workflows/main.yml` からpullrequestのトリガーを削除
* `api_server/views.py` を修正し， `/api/v1` で返却されるjsonのメッセージを変更