### PR TITLE
DBとしてMySQLを使うよう変更

### DIFF
--- a/sample_api/views.py
+++ b/sample_api/views.py
@@ -1,6 +1,7 @@
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from .models import GirlsLove
+import json
 
 
 @csrf_exempt
@@ -20,6 +21,14 @@ def index(request):
         response["content"] = content
         return JsonResponse(data=response)
     elif request.method == 'POST':
-        return JsonResponse(data={"message": "nothing done"})
+        request_json = json.loads(request.body)
+
+        girls_love = GirlsLove()
+        girls_love.follower_name = request_json['follower_name']
+        girls_love.followee_name = request_json['followee_name']
+        girls_love.save()
+
+        return JsonResponse(data={"message":
+                                  "successfully added a new girls love"})
     else:
         return JsonResponse(data={"message": "unexpetected http method"}, status=400)

--- a/spajam2020_django/settings.py
+++ b/spajam2020_django/settings.py
@@ -78,8 +78,12 @@ WSGI_APPLICATION = 'spajam2020_django.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': os.environ['MYSQL_HOST'],
+        'PORT': os.environ['MYSQL_PORT'],
+        'NAME': os.environ['MYSQL_DB_NAME'],
+        'USER': os.environ['MYSQL_USER'],
+        'PASSWORD': os.environ['MYSQL_PASSWORD'],
     }
 }
 


### PR DESCRIPTION
## 概要
* 使用するDBをsqliteからMySQLに変更
* GirlsLoveテーブルのレコードを追加するAPIエンドポイントを追加

## 技術的変更点
* `spajam2020_django/settings.py` を修正し，mysqlを使用するよう変更
* `sample_api/views.py` に POSTメソッドでjsonを受け取り，`GirlsLove` テーブルにレコードを追加するAPIエンドポイントを作成

## 動作確認方法
1. `.env` を沖本からもらって，リポジトリのルートディレクトリに配置
1. `requirements.txt` から `mysqlclient` のコメントアウトを取り除き， `$ pip install -r requirements.txt` で `mysqlclient` をインストール
1. docker-composeでMySQLのコンテナを立てる
1. `$ python manage.py migrate` でDBをmigrate
1. `$ python manage.py runserver` でサーバー起動
1. `$ curl  localhost:8000/sample_api/` で，MySQLにアクセス出来ることを確認
1. `$ curl -X POST --data '{"follower_name":"momo", "followee_name":"shamiko"}' localhost:8000/sample_api/` で新しいGirlsLoveを追加
1. 再び `$ curl  localhost:8000/sample_api/` で，shamimomoが追加されていることを確認